### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ test-env-redo:
 
 reset-db:
 	diesel database reset
+	diesel migration run
 
 .PHONY: prepare docs lib-docs api-docs fmt \
 		test test-dev lint audit commit \


### PR DESCRIPTION
Always run diesel migration run when `make reset-db` to trigger schema code generator to the latest one.