### PR TITLE
Fixup directory name at docs generator 

### DIFF
--- a/etc/script/gen_api_docs.py
+++ b/etc/script/gen_api_docs.py
@@ -5,7 +5,7 @@ import os
 import json
 import re
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", "..", "libs", "$name_snake_case$-client-py"))
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "..", "libs", "$name_kebab_case$-client-py"))
 
 import $name_snake_case$
 

--- a/etc/script/gen_test_users.py
+++ b/etc/script/gen_test_users.py
@@ -3,7 +3,7 @@
 import sys
 import os
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", "..", "libs", "$name_snake_case$-client-py"))
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "..", "libs", "$name_kebab_case$-client-py"))
 
 import $name_snake_case$
 


### PR DESCRIPTION
There will be an error on generating api documentation if there is more than one word project name is used. This PR resolved the problem on formatting path to call the python library required by the generator.